### PR TITLE
update checkImageDomainAllowedContainer

### DIFF
--- a/source/source.go
+++ b/source/source.go
@@ -12,6 +12,14 @@ const (
 	SourceUnappoved = "SourceSentry: pod rejected because image is not in allowed list"
 )
 
+func Min(a, b int) int {
+	if a > b {
+		return b
+	} else {
+		return a
+	}
+}
+
 type SourceSentry struct {
 	allowedSources []string
 }
@@ -55,7 +63,7 @@ func (ss *SourceSentry) checkImageDomainAllowedContainer(cs []corev1.Container) 
 	for _, c := range cs {
 		pass := false
 		for _, v := range ss.allowedSources {
-			if c.Image[0:len(v)] == v {
+			if c.Image[0:Min(len(v), len(c.Image))] == v {
 				log.Infof("Found approved source %v for container %v", v, c.Image)
 				pass = true
 			}

--- a/test-manifests/source/source.fail2.yaml
+++ b/test-manifests/source/source.fail2.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test4
+  labels:
+    name: test4
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name:      sourcefail
+  namespace: test4
+  labels:
+    test: label
+spec:
+  containers:
+    - name:  pause
+      image: nginx

--- a/test-manifests/source/source.fail3.yaml
+++ b/test-manifests/source/source.fail3.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test4
+  labels:
+    name: test4
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name:      sourcefail
+  namespace: test4
+  labels:
+    test: label
+spec:
+  containers:
+    - name:  pause
+      image: registry.hub.docker.com/library/nginx


### PR DESCRIPTION
With the original code the image comparison was failing with nasty error
 ` panic serving 10.0.2.15:32864: runtime error: slice bounds out of range
goroutine 41 [running]:
net/http.(*http2serverConn).runHandler.func1(0xc420090478, 0xc420355faf, 0xc420136e00)
	/usr/local/go/src/net/http/h2_bundle.go:5753 +0x190
panic(0xafd500, 0x10447e0)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/jasonrichardsmith/sentry/source.(*SourceSentry).checkImageDomainAllowedContainer(0xc420355990, 0xc420241400, 0x1, 0x1, 0xc42013a100)
	/go/src/github.com/jasonrichardsmith/sentry/source/source.go:58 +0x2e2
github.com/jasonrichardsmith/sentry/source.(*SourceSentry).checkImageDomainAllowed(0xc420355990, 0x0, 0x0, 0x0, 0x0, 0xc42044c054, 0xa, 0x0, 0x0, 0xc42044c069, ...)
	/go/src/github.com/jasonrichardsmith/sentry/source/source.go:43 +0x56
github.com/jasonrichardsmith/sentry/source.SourceSentry.Admit(0xc420264220, 0x1, 0x1, 0xc4202e8d10, 0xf, 0xc4203211e0, 0x18, 0xc4202412c0, 0x0, 0x1)
	/go/src/github.com/jasonrichardsmith/sentry/source/source.go:34 +0x295
github.com/jasonrichardsmith/sentry/mux.SentryMux.Admit(0xc420240a00, 0x5, 0x8, 0xc4202e8d10, 0xf, 0xc4203211e0, 0x18, 0xc4202412c0, 0x0, 0xc4200b0d40)
	/go/src/github.com/jasonrichardsmith/sentry/mux/mux.go:55 +0x358
github.com/jasonrichardsmith/sentry/sentry.SentryHandler.ServeHTTP(0xc57380, 0xc420258d00, 0xc5d5c0, 0xc420090478, 0xc42013ba00)
	/go/src/github.com/jasonrichardsmith/sentry/sentry/sentry.go:81 +0x653
net/http.serverHandler.ServeHTTP(0xc4201dcd00, 0xc5d5c0, 0xc420090478, 0xc42013ba00)
	/usr/local/go/src/net/http/server.go:2697 +0xbc
net/http.initNPNRequest.ServeHTTP(0xc4201df880, 0xc4201dcd00, 0xc5d5c0, 0xc420090478, 0xc42013ba00)
	/usr/local/go/src/net/http/server.go:3263 +0x9a
net/http.(Handler).ServeHTTP-fm(0xc5d5c0, 0xc420090478, 0xc42013ba00)
	/usr/local/go/src/net/http/h2_bundle.go:5475 +0x4d
net/http.(*http2serverConn).runHandler(0xc420136e00, 0xc420090478, 0xc42013ba00, 0xc420259b60)
	/usr/local/go/src/net/http/h2_bundle.go:5760 +0x89
created by net/http.(*http2serverConn).processHeaders
	/usr/local/go/src/net/http/h2_bundle.go:5494 +0x46b
`

the small change fixes this. Please check it and I would be happy if you can merge it.